### PR TITLE
:arrow_up: Bump Python to 3.8.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN curl -fsSL https://rpm.nodesource.com/setup_14.x | bash - && \
 
 ENV PATH=/usr/local/bin:$PATH \
     LANG=C.UTF-8 \
-    PYTHON_VERSION=3.8.10
+    PYTHON_VERSION=3.8.11
 
 RUN yum install gcc \
     zlib-devel \


### PR DESCRIPTION
This commit is to bump Python from 3.8.10 to 3.8.11.

This change is included security fix.
Details see [Python Changelog](https://docs.python.org/release/3.8.11/whatsnew/changelog.html#changelog).
